### PR TITLE
fix: metaevidence block range off by one

### DIFF
--- a/functions/notice-metaevidence-background.ts
+++ b/functions/notice-metaevidence-background.ts
@@ -30,7 +30,7 @@ export const getMetaEvidenceUriFromLogs = async (
   const startBlock = klerosStartBlock[chainId];
   return (
     await Promise.all(
-      [...Array(Number((toBlock - startBlock) / batchSize)).keys()].map(
+      [...Array(Number((toBlock - startBlock) / batchSize) + 1).keys()].map(
         (idx) => {
           const fromBlock = startBlock + batchSize * BigInt(idx);
           console.log({


### PR DESCRIPTION
BigInt division rounds down, hence the toBlock calculation is off by one.

This PR implements a simple fix